### PR TITLE
Add additional varnish run parameter

### DIFF
--- a/cmd/kube-httpcache/internal/flags.go
+++ b/cmd/kube-httpcache/internal/flags.go
@@ -42,10 +42,11 @@ type KubeHTTPProxyFlags struct {
 		Port    int
 	}
 	Varnish struct {
-		SecretFile      string
-		Storage         string
-		VCLTemplate     string
-		VCLTemplatePoll bool
+		SecretFile          string
+		Storage             string
+		AdditionalParameter string
+		VCLTemplate         string
+		VCLTemplatePoll     bool
 	}
 }
 
@@ -82,6 +83,7 @@ func (f *KubeHTTPProxyFlags) Parse() error {
 	flag.StringVar(&f.Varnish.SecretFile, "varnish-secret-file", "/etc/varnish/secret", "Varnish secret file")
 	flag.StringVar(&f.Varnish.Storage, "varnish-storage", "file,/tmp/varnish-data,1G", "varnish storage config")
 	flag.StringVar(&f.Varnish.VCLTemplate, "varnish-vcl-template", "/etc/varnish/default.vcl.tmpl", "VCL template file")
+	flag.StringVar(&f.Varnish.AdditionalParameter, "varnish-additional-parameter", "", "Additional varnish start parameter (-p, seperate by comma), like 'ban_dups=on,cli_timeout=30'")
 	flag.BoolVar(&f.Varnish.VCLTemplatePoll, "varnish-vcl-template-poll", false, "poll for file changes instead of using inotify (useful on some network filesystems)")
 
 	flag.Parse()

--- a/cmd/kube-httpcache/main.go
+++ b/cmd/kube-httpcache/main.go
@@ -112,6 +112,7 @@ func main() {
 	varnishController, err := controller.NewVarnishController(
 		opts.Varnish.SecretFile,
 		opts.Varnish.Storage,
+		opts.Varnish.AdditionalParameter,
 		opts.Frontend.Address,
 		opts.Frontend.Port,
 		opts.Admin.Address,

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -19,6 +19,7 @@ type TemplateData struct {
 type VarnishController struct {
 	SecretFile   string
 	Storage      string
+	AdditionalParameter string
 	FrontendAddr string
 	FrontendPort int
 	AdminAddr    string
@@ -40,6 +41,7 @@ type VarnishController struct {
 func NewVarnishController(
 	secretFile string,
 	storage string,
+	additionalParameter string,
 	frontendAddr string,
 	frontendPort int,
 	adminAddr string,
@@ -66,19 +68,20 @@ func NewVarnishController(
 	}
 
 	return &VarnishController{
-		SecretFile:         secretFile,
-		Storage:            storage,
-		FrontendAddr:       frontendAddr,
-		FrontendPort:       frontendPort,
-		AdminAddr:          adminAddr,
-		AdminPort:          adminPort,
-		vclTemplate:        tmpl,
-		vclTemplateUpdates: templateUpdates,
-		frontendUpdates:    frontendUpdates,
-		backendUpdates:     backendUpdates,
-		varnishSignaller:   varnishSignaller,
-		configFile:         "/tmp/vcl",
-		secret:             secret,
+		SecretFile:          secretFile,
+		Storage:             storage,
+		AdditionalParameter: additionalParameter,
+		FrontendAddr:        frontendAddr,
+		FrontendPort:        frontendPort,
+		AdminAddr:           adminAddr,
+		AdminPort:           adminPort,
+		vclTemplate:         tmpl,
+		vclTemplateUpdates:  templateUpdates,
+		frontendUpdates:     frontendUpdates,
+		backendUpdates:      backendUpdates,
+		varnishSignaller:    varnishSignaller,
+		configFile:          "/tmp/vcl",
+		secret:              secret,
 	}, nil
 }
 


### PR DESCRIPTION
# Additional running parameter
In the current version, it's not possible to start varnish with additional run parameter (https://varnish-cache.org/docs/6.0/reference/varnishd.html#list-of-parameters).

This PR add this possibility with a simple generic approach.

Tested on a local minikube.