### PR TITLE
Do not mark "help wanted" issues as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
           There has not been any activity to this issue in the last 14 days.
           It will automatically be closed after 7 more days. Remove the `stale` label to prevent this.
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'accepted,confirmed,help wanted'
+        exempt-issue-labels: 'accepted,confirmed,help%20wanted'
 
         stale-pr-message: >
           There has not been any activity to this pull request in the last 14 days.


### PR DESCRIPTION
Exempt issue names apparently need to be specified with URL encoding (see actions/stale#98).