### PR TITLE
Make service names match in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ kubectl create rolebinding kube-httpcache --clusterrole=kube-httpcache --servi
     apiVersion: v1
     kind: Service
     metadata:
-      name: cache-service
+      name: frontend-service
       labels:
         app: cache
     spec:


### PR DESCRIPTION
The StatefulSet was using frontend-service but the service was named cache-service in the example