### PR TITLE
Added the environment variable parsing for the configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ data:
     # ...
 ```
 
+Environment variables can be used from the template. `{{ .Env.ENVVAR }}` is replaced with the
+environment variable value. This can be used to set for example the Host-header for the external 
+service.
+
 ### Create a Secret
 
 Create a `Secret` object that contains the secret for the Varnish administration port:


### PR DESCRIPTION
At the Varnish configuration template the {{ .Env.ENVVAR }} is changed to the value of the environment variable. If the environment variable doesn't exist, this crashes.