### PR TITLE
Improve Helm chart documentation, and add warning to NOTES.txt in edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,10 +392,15 @@ When starting kube-httpcache, remember to set the `--backend-watch=false` flag t
 
 ## Helm Chart installation
 
-Using [HELM](chart/) to rollout an instance of kube-httpcache.
+You can use the [Helm chart](chart/) to rollout an instance of kube-httpcache:
 
-Ensure your defined backen services have a port
-name `http`:
+```
+$ helm install -f your-values.yaml kube-httpcache ./chart
+```
+
+For possible values, have a look at the comments in the provided [`values.yaml` file](./chart/values.yaml).
+
+Ensure your defined backend services have a port named `http`:
 
 ```
 apiVersion: v1

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,3 +1,11 @@
 Ensure your backend-service has a port name 'http' and create an ingress
-point to the kube-httpcache service. Enjoy your Varnish cache!
+points to the '{{ include "kube-httpcache.fullname" . }}' service. Enjoy your Varnish cache!
 
+{{- if and (.Values.rbac.enabled) (.Values.cache.backendServiceNamespace) (ne .Values.cache.backendServiceNamespace .Release.Namespace) }}
+
+ATTENTION REQUIRED:
+Your backend service is configured as {{ .Values.cache.backendServiceNamespace }}/{{ .Values.cache.backendService}} and is in a different namespace
+than your Helm release ({{ .Release.Namespace}}). To be able to watch the endpoints of this service,
+the '{{ include "kube-httpcache.serviceAccountName" . }}' service account will need to be granted WATCH access
+to the "endpoints" resource in the namespace '{{ .Values.cache.backendServiceNamespace }}' using RBAC.
+{{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,11 +1,13 @@
 Ensure your backend-service has a port name 'http' and create an ingress
 points to the '{{ include "kube-httpcache.fullname" . }}' service. Enjoy your Varnish cache!
 
-{{- if and (.Values.rbac.enabled) (.Values.cache.backendServiceNamespace) (ne .Values.cache.backendServiceNamespace .Release.Namespace) }}
+{{- if and (.Values.rbac.enabled) (.Values.cache.backendServiceNamespace) }}
+{{- if (ne .Values.cache.backendServiceNamespace .Release.Namespace) }}
 
 ATTENTION REQUIRED:
 Your backend service is configured as {{ .Values.cache.backendServiceNamespace }}/{{ .Values.cache.backendService}} and is in a different namespace
 than your Helm release ({{ .Release.Namespace}}). To be able to watch the endpoints of this service,
 the '{{ include "kube-httpcache.serviceAccountName" . }}' service account will need to be granted WATCH access
 to the "endpoints" resource in the namespace '{{ .Values.cache.backendServiceNamespace }}' using RBAC.
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adds a warning note to the `NOTES.txt` output in certain edge cases.

This is a follow-up to a discussion in https://github.com/mittwald/kube-httpcache/pull/51#discussion_r580575588.