### PR TITLE
Fix a memory leak in Signaller.ProcessSignalQueue due to an unclosed response body

### DIFF
--- a/pkg/signaller/run.go
+++ b/pkg/signaller/run.go
@@ -68,6 +68,12 @@ func (b *Signaller) ProcessSignalQueue() {
 		} else {
 			glog.V(5).Infof("recieved a signal response from %s: %+v", response.Request.URL.Host, response)
 		}
+
+		if response != nil {
+			if err := response.Body.Close(); err != nil {
+				glog.Error("error on closing response body:", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
A memory leak is caused by an unclosed response body when a high volume of incoming PURGE requests is propagated among instances of a Varnish cluster.

Before changes:
```
    1 root      20   0   20.7g  20.0g  15544 S   0.0  35.4 186:05.55 kube-httpcache
     22 varnish   20   0   18564   4488   3800 S   0.0   0.0   0:33.54 varnishd
     34 vcache    20   0 4873816   3.0g  85248 S   0.0   5.3 450:00.98 cache-main
```

After changes:
```
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
     35 vcache    20   0 2760588   1.4g  86308 S 640.0   2.6 128:44.85 cache-main
      1 root      20   0  730008  27248  15316 S 126.7   0.0  28:55.55 kube-httpcache
     23 varnish   20   0   18568   5544   4888 S   0.0   0.0   0:00.75 varnishd
```