### PR TITLE
added option to disable frontendwatch to helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
           - -admin-port=6083
           - -signaller-enable
           - -signaller-port=8090
+          {{- if .Values.cache.frontendWatch }}
           - -frontend-watch
+          {{- else }}
+          - -frontend-watch=false
+          {{- end }}
           - -frontend-namespace={{ "$(NAMESPACE)" }}
           - -frontend-service={{ include "kube-httpcache.fullname" . }}
           {{- if .Values.cache.backendWatch }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -47,7 +47,11 @@ spec:
           - -admin-port=6083
           - -signaller-enable
           - -signaller-port=8090
+          {{- if .Values.cache.frontendWatch }}
           - -frontend-watch
+          {{- else }}
+          - -frontend-watch=false
+          {{- end }}
           - -frontend-namespace={{ "$(NAMESPACE)" }}
           - -frontend-service={{ include "kube-httpcache.fullname" . }}
           {{- if .Values.cache.backendWatch }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,6 +28,8 @@ cache:
   backendService: backend-service
   # name of backend service namespace
   # backendServiceNamespace: backend-service-namespace
+  # watching for frontend changes is true by default
+  frontendWatch: true
   # watching for backend changes is true by default
   backendWatch: true
   # Varnish storage backend type (https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html)


### PR DESCRIPTION
In cases in which we don't use frontend-watch we need an option to disable this.
Imho it's also not possible to use frontend-watch and readinessProbes at the same time.