### PR TITLE
Add extra options to helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
             {{- toYaml .Values.exporter.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- if .Values.extraContainers }}
+          {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       volumes:
       {{- if .Values.configmap.enabled }}
       - name: template

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: template
             mountPath: /etc/varnish/tmpl

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -156,4 +156,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - -signaller-port=8090
           - -frontend-watch
           - -frontend-namespace={{ "$(NAMESPACE)" }}
-          - -frontend-service={{ include "kube-httpcache.fullname" . }}
+          - -frontend-service={{ .Values.cache.frontendService | default (include "kube-httpcache.fullname" .) }}
           {{- if .Values.cache.backendWatch }}
           - -backend-watch
           {{- else }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -157,4 +157,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
           - -signaller-port=8090
           - -frontend-watch
           - -frontend-namespace={{ "$(NAMESPACE)" }}
-          - -frontend-service={{ include "kube-httpcache.fullname" . }}
+          - -frontend-service={{ .Values.cache.frontendService | default (include "kube-httpcache.fullname" .) }}
           {{- if .Values.cache.backendWatch }}
           - -backend-watch
           {{- else }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -128,6 +128,9 @@ spec:
             {{- toYaml .Values.exporter.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- if .Values.extraContainers }}
+          {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       volumes:
      {{- if .Values.configmap.enabled }}
       - name: template

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -70,6 +70,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: template
             mountPath: /etc/varnish/tmpl

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,8 @@ configmap:
 # kube-httpcache specific configuration
 cache:
   # name of backend service
+  # frontendService: kube-httpcache-headless
+  # name of backend service
   backendService: backend-service
   # name of backend service namespace
   # backendServiceNamespace: backend-service-namespace

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,6 +78,14 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command:
+  #     - /bin/sh
+  #     - -c
+  #     - touch /etc/varnish/fail_probes; sleep 25
+
 initContainers: {}
 # initContainers: |
 #   - args:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -103,7 +103,13 @@ initContainers: {}
 #     volumeMounts:
 #     - name: template
 #       mountPath: /etc/varnish/tmpl
-#
+
+extraContainers: []
+# - name: my-sidecar
+#   image: myapp/my-sidecar
+#   command:
+#   - my-sidecar-command
+
 extraVolumes: {}
 # extraVolumes:
 #   - emptyDir: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -199,6 +199,8 @@ nodeSelector: {}
 
 tolerations: []
 
+#terminationGracePeriodSeconds: 60
+
 affinity: {}
 
 livenessProbe: {}


### PR DESCRIPTION
This options has been useful for the way we have being using this 
project

- add helm option to change the frontend service name
- add helm option to set varnish container lifecycle options
- add helm option to add extracontainers to the pod
- add helm option to set the pod termination grace period
