### PR TITLE
Add option to use a user provided secret for the admin credentials

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -142,7 +142,7 @@ spec:
       {{- end }}
       - name: secret
         secret:
-          secretName: {{ include "kube-httpcache.fullname" . }}
+          secretName: {{ .Values.cache.existingSecret | default (include "kube-httpcache.fullname" .) }}
       - name: var
         emptyDir: {}
       {{- if .Values.extraVolumes -}}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.cache.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   secret: {{ .Values.cache.secret | default (randAlphaNum 32) | b64enc | quote }}
+{{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -143,7 +143,7 @@ spec:
      {{- end }}
       - name: secret
         secret:
-          secretName: {{ include "kube-httpcache.fullname" . }}
+          secretName: {{ .Values.cache.existingSecret | default (include "kube-httpcache.fullname" .) }}
       - name: var
         emptyDir: {}
       {{- if .Values.extraVolumes }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,6 +40,8 @@ cache:
   storageSize: 128M # K(ibibytes), M(ebibytes), G(ibibytes), T(ebibytes) ... unlimited
   # Secret for Varnish admin credentials
   #secret: "12345678"
+  # Read admin credentials from user provided secret
+  #existingSecret: kubecache-secret
   # File name for Varnish template
   template: varnish.tpl
 


### PR DESCRIPTION
This PR adds an option to use an existing secret for the admin credentials..

This comes in need to fix this issue #56 
I'm really sure why is needed, in this comment https://github.com/mittwald/kube-httpcache/pull/51#discussion_r547112352 you mentioned that if the secret is updated it shouldn't be used until the pods are restarted.