### PR TITLE
Remove unused config parameter

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kube-httpcache
 description: Varnish on Kubernetes Helm Chart
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 home: https://varnish-cache.org
 icon: https://varnish-cache.org/_static/varnish-bunny.png

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,8 +42,6 @@ cache:
   #secret: "12345678"
   # Read admin credentials from user provided secret
   #existingSecret: kubecache-secret
-  # File name for Varnish template
-  template: varnish.tpl
 
 cacheExtraArgs: {}
 # cacheExtraArgs: |


### PR DESCRIPTION
`cache.template` does not seem to be used anywhere. The filename of the rendered VCL is hard-coded in the constructor of [`VarnishController`](https://github.com/mittwald/kube-httpcache/blob/master/pkg/controller/types.go#L89)