### PR TITLE
Helm: add support for topologySpreadConstraints.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccountName: {{ include "kube-httpcache.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- with .Values.initContainers }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "kube-httpcache.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- with .Values.initContainers }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -92,6 +92,20 @@ lifecycle: {}
   #     - -c
   #     - touch /etc/varnish/fail_probes; sleep 25
 
+topologySpreadConstraints: {}
+  # - topologyKey: topology.kubernetes.io/zone
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: kube-httpcache
+  # - topologyKey: kubernetes.io/hostname
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: kube-httpcache
+
 initContainers: {}
 # initContainers: |
 #   - args:
@@ -218,10 +232,10 @@ readinessProbe: {}
 
 vclTemplate: |
   vcl 4.0;
-  
+
   import std;
   import directors;
-  
+
   // ".Frontends" is a slice that contains all known Varnish instances
   // (as selected by the service specified by -frontend-service).
   // The backend name needs to be the Pod name, since this value is compared
@@ -234,35 +248,35 @@ vclTemplate: |
       .port = "{{ .Port }}";
   }
   {{- end }}
-  
+
   {{ range .Backends }}
   backend be-{{ .Name }} {
       .host = "{{ .Host }}";
       .port = "{{ .Port }}";
   }
   {{- end }}
-  
+
   sub vcl_init {
       new cluster = directors.hash();
-  
+
       {{ range .Frontends -}}
       cluster.add_backend({{ .Name }}, 1);
       {{ end }}
-  
+
       new lb = directors.round_robin();
-  
+
       {{ range .Backends -}}
       lb.add_backend(be-{{ .Name }});
       {{ end }}
   }
-  
+
   sub vcl_recv
   {
       # Set backend hint for non cachable objects.
       set req.backend_hint = lb.backend();
-  
+
       # ...
-  
+
       # Routing logic. Pass a request to an appropriate Varnish node.
       # See https://info.varnish-software.com/blog/creating-self-routing-varnish-cluster for more info.
       unset req.http.x-cache;
@@ -272,8 +286,8 @@ vclTemplate: |
           return(pass);
       }
       set req.backend_hint = lb.backend();
-  
+
       # ...
-  
+
       return(hash);
   }


### PR DESCRIPTION
# Description

This PR intends to add the support for K8s `topologySpreadConstraints` mechanism.

The purpose of this concept is to control how Pods are being scheduled in K8s clusters ([official documentation here](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/))

# Details of the PR 
- Support proposed to `Deployment` as well as `StatefulSet` resources
- Render has been tested through `helm lint` & `helm template`
- Suggested commented configuration suggests HA (1 instance per host + cross-AZ repartition as a best-effort)
- The feature is supported as of kubernetes 1.19

# Notes

Thanks for open-sourcing this awesome project ! 🙂 