### PR TITLE
Helm: add logger sidecar.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -138,6 +138,38 @@ spec:
             {{- toYaml .Values.exporter.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- if .Values.logger.enabled }}
+        - name: logger
+          securityContext:
+            {{- toYaml .Values.logger.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - varnishncsa
+          args:
+          - -a
+          {{- if .Values.logger.format }}
+          - {{- printf " -F %s" (toJson .Values.logger.format) }}
+          {{- end }}
+          env:
+          - name: VSM_NOPID
+            value: "1"
+          volumeMounts:
+          - name: var
+            mountPath: /var/lib/varnish
+          {{- if .Values.logger.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.logger.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.logger.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.logger.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.logger.resources }}
+          resources:
+            {{- toYaml .Values.logger.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.extraContainers }}
           {{- toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -139,6 +139,41 @@ spec:
         {{- if .Values.extraContainers }}
           {{- toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.logger.enabled }}
+        - name: logger
+          securityContext:
+            {{- toYaml .Values.logger.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - varnishncsa
+          args:
+          - -a
+          {{- if .Values.logger.format }}
+          - {{- printf " -F %s" (toJson .Values.logger.format) }}
+          {{- end }}
+          env:
+          - name: VSM_NOPID
+            value: "1"
+          volumeMounts:
+          - name: var
+            mountPath: /var/lib/varnish
+          {{- if .Values.logger.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.logger.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.logger.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.logger.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.logger.resources }}
+          resources:
+            {{- toYaml .Values.logger.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.extraContainers }}
+          {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       volumes:
      {{- if .Values.configmap.enabled }}
       - name: template

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -157,6 +157,35 @@ exporter:
   #    port: 6083
   readinessProbe: {}
 
+logger:
+  enabled: false
+  # format:
+  #   '@timestamp': '%{%Y-%m-%dT%H:%M:%S%z}t'
+  #   '@version': '1'
+  #   'vips': '%{host}i'
+  #   'tags': '["varnish"]'
+  #   'message': '%h %l %u %t \\%r\\ %s %b'
+  #   'clientip': '%h'
+  #   'duration': '%D'
+  #   'status': '%s'
+  #   'request': '%U%q'
+  #   'urlpath': '%U'
+  #   'urlquery': '%q'
+  #   'bytes': '%b'
+  #   'method': '%m'
+  #   'referer': '%{Referer}i'
+  #   'useragent': '%{User-agent}i'
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: false
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  resources: {}
+  livenessProbe: {}
+  readinessProbe: {}
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
# Description

The new logger sidecar leverages varnishncsa bin to logs to the stdout varnish activity on the main container of the pod. The values.yml suggests a default JSON file format for better logging librairies parsing.

No memory leaks nor weird comportment expected with this new sidecar, nor conflict with the exporter.
The Docker image remains the same for the three containers of the pods.

# Example of logs

This uses the recommended JSON format for the logs :
```bash
{"@timestamp":"2021-09-04T10:28:39+0000","@version":"1","bytes":"282","clientip":"100.121.83.198","duration":"413","message":"100.121.83.198 - - [04/Sep/2021:10:28:39 +0000] \\GET http://test.org/favicon-32x32.png HTTP/1.1\\ 503 282","method":"GET","referer":"http://test.org/","request":"/favicon-32x32.png","status":"503","tags":"["varnish"]","urlpath":"/favicon-32x32.png","urlquery":"","useragent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36","vips":"test.org"}
```