### PR TITLE
Watch: Drop previous VCL version when reloading.

### DIFF
--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -97,6 +97,10 @@ func (v *VarnishController) rebuildConfig(ctx context.Context, i int) error {
 		glog.V(1).Infof("error while changing state of VCL %s: %s", v.currentVCLName, err)
 	}
 
+	if err := client.DiscardVCL(ctx, v.currentVCLName); err != nil {
+		glog.V(1).Infof("error while discarding previous VCL version %s: %s", v.currentVCLName, err)
+	}
+
 	v.currentVCLName = configname
 
 	return nil


### PR DESCRIPTION
# Description

As stated by @timkante in issue #81, Varnish keeps all previous VCL versions after reloads. This increases the memory consumption of Varnish over time and can be deadly if the configuration gets repeatedly reloaded (because of autoscaling related behaviors for example).

This commit intends to keep to 1 the list of VCLs in the history.