### PR TITLE
Varnish: Change default port from 80 to 8080.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
           - -admin-port=6083
           - -signaller-enable
           - -signaller-port=8090
+          - -frontend-port={{ .Values.service.target }}
           {{- if .Values.cache.frontendWatch }}
           - -frontend-watch
           {{- else }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -51,6 +51,7 @@ spec:
           - -admin-port=6083
           - -signaller-enable
           - -signaller-port=8090
+          - -frontend-port={{ .Values.service.target }}
           {{- if .Values.cache.frontendWatch }}
           - -frontend-watch
           {{- else }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -160,7 +160,7 @@ exporter:
 service:
   type: ClusterIP
   port: 80
-  target: 80
+  target: 8080
 
 ingress:
   enabled: false

--- a/cmd/kube-httpcache/internal/flags.go
+++ b/cmd/kube-httpcache/internal/flags.go
@@ -64,7 +64,7 @@ func (f *KubeHTTPProxyFlags) Parse() error {
 	flag.StringVar(&f.Kubernetes.RetryBackoffString, "retry-backoff", "30s", "backoff for Kubernetes API reconnection attempts")
 
 	flag.StringVar(&f.Frontend.Address, "frontend-addr", "0.0.0.0", "TCP address to listen on")
-	flag.IntVar(&f.Frontend.Port, "frontend-port", 80, "TCP port to listen on")
+	flag.IntVar(&f.Frontend.Port, "frontend-port", 8080, "TCP port to listen on")
 
 	flag.BoolVar(&f.Frontend.Watch, "frontend-watch", false, "watch for Kubernetes frontend updates")
 	flag.StringVar(&f.Frontend.Namespace, "frontend-namespace", "", "name of Kubernetes frontend namespace")


### PR DESCRIPTION
# Description

The port 8080 is a "standard" HTTP port for applications running inside a private infrastructure. As the default HTTP port (80) is a system port, it is not possible to restrain permissions through the securityContext and drop rootUser out-of-the-box. This will result in a permission error while trying to create a socket on port 80.

This commit intends to fix this and make the application of the securityContext
(required in most if not every production clusters) a lot more simple.

## Notes
⚠️ This is a breaking change from previous versions

## Example of error when enabling securityContext

```bash
k logs -f kube-httpcache-7dd77678c9-bcsxb
I0901 17:33:33.859847       1 main.go:31] running kube-httpcache with following options: {Kubernetes:{Config: RetryBackoffString:30s RetryBackoff:30s} Frontend:{Address:0.0.0.0 Port:80 Watch:true Namespace:staging Service:kube-httpcache PortName:http} Backend:{Watch:true Namespace:staging Service:example Port: PortName:http} Signaller:{Enable:true Address:0.0.0.0 Port:8090 WorkersCount:1 MaxRetries:5 RetryBackoffString:30s RetryBackoff:30s QueueLength:0} Admin:{Address:0.0.0.0 Port:6083} Varnish:{SecretFile:/etc/varnish/k8s-secret/secret Storage:malloc,1G TransientStorage:malloc,128m AdditionalParameters: VCLTemplate:/etc/varnish/tmpl/default.vcl.tmpl VCLTemplatePoll:false WorkingDir:} Readiness:{Enable:true Address:0.0.0.0:9102}}
I0901 17:33:33.860015       1 main.go:38] using in-cluster configuration
I0901 17:33:33.862241       1 run.go:15] waiting for initial configuration before starting Varnish
W0901 17:33:33.874374       1 endpoints_watch.go:66] service 'kube-httpcache' has no endpoints
I0901 17:33:33.963765       1 run.go:35] creating initial VCL config
I0901 17:33:33.964194       1 wait.go:12] probing admin port until it is available
I0901 17:33:34.003332       1 endpoints_watch.go:73] endpoints did not change
Error: Could not get socket 0.0.0.0:80: Permission denied
(-? gives usage)
I0901 17:33:42.969529       1 endpoints_watch.go:73] endpoints did not change
```