### PR TITLE
README: Align ACL examples content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ data:
 ```
 
 Environment variables can be used from the template. `{{ .Env.ENVVAR }}` is replaced with the
-environment variable value. This can be used to set for example the Host-header for the external 
+environment variable value. This can be used to set for example the Host-header for the external
 service.
 
 ### Create a Secret
@@ -316,7 +316,7 @@ sub vcl_recv {
 
   # Purge logic
   if (req.method == "PURGE") {
-    if (client.ip !~ privileged) {
+    if (client.ip !~ purgers) {
       return (synth(403, "Not allowed."));
     }
     if (req.http.X-Host) {
@@ -327,7 +327,7 @@ sub vcl_recv {
 
   # Ban logic
   if (req.method == "BAN") {
-    if (client.ip !~ privileged) {
+    if (client.ip !~ purgers) {
       return (synth(403, "Not allowed."));
     }
     if (req.http.Cache-Tags) {
@@ -418,7 +418,7 @@ spec:
   type: ClusterIP
 ```
 
-An ingress points to the kube-httpcache service which cached 
+An ingress points to the kube-httpcache service which cached
 your backend service:
 
 ```


### PR DESCRIPTION
# Description

2 parts of the README mention the ACLs.
As a lot of newcomers to FOSS projects tends to follow documentations insights  & copy/paste examples to build a simple configuration to start with, I believe it's worth reducing the chances they face a broken configuration.

**TL;DR:** This PR ensures the examples are following the same ACL naming conventions 🙂 