### PR TITLE
Docker: Leave `apt-transport-https` package installed in image (#107)

### DIFF
--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN         set -x \
             && \
             apt-get -qq update && apt-get -qq install varnish \
             && \
-            apt-get -qq purge curl gnupg apt-transport-https && \
+            apt-get -qq purge curl gnupg && \
             apt-get -qq autoremove && apt-get -qq autoclean && \
             rm -rf /var/cache/*
 


### PR DESCRIPTION
after building locally:

```
# apt update
...
Hit:6 https://packagecloud.io/varnishcache/varnish60lts/debian stretch InRelease
Reading package lists... Done
Building dependency tree       
Reading state information... Done
All packages are up to date.
```