### PR TITLE
Helm: Allow label customization for servicemonitor

### DIFF
--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,10 +1,13 @@
-{{- if .Values.serviceMonitor -}}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "kube-httpcache.fullname" . }}
   labels:
     {{- include "kube-httpcache.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -12,5 +15,10 @@ spec:
   endpoints:
   - port: metrics
     path: /metrics
-    interval: 10s
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
 {{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -65,7 +65,15 @@ rbac:
   enabled: true
 
 # create a prometheus operator ServiceMonitor
-serviceMonitor: false
+serviceMonitor:
+  enabled: false
+
+  additionalLabels: {}
+  ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+  interval: 10s
+  ## Scrape Timeout. If not set, the Prometheus default scrape timeout is used.
+  scrapeTimeout: ""
+
 
 podSecurityPolicy:
   enabled: false


### PR DESCRIPTION
* Allows control of the scrape interval + timeout
* Allows setting of extra labels on the ServiceMonitor object


A breaking-ish change as the `serviceMonitor` config key is no longer a bool.

I needed this as my prometheus deployment is expecting ServiceMonitors with the specific release label.

eg. 
``` yaml
serviceMonitor:
  additionalLabels:
    release: kube-prometheus-stack
```