### PR TITLE
Dockerfiles: bump exporter version

### DIFF
--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN         CGO_ENABLED=0 GOOS=linux \
 
 FROM        debian:stretch-slim AS final
 
-ENV         EXPORTER_VERSION=1.6
+ENV         EXPORTER_VERSION=1.6.1
 
 LABEL       MAINTAINER="Martin Helmich <m.helmich@mittwald.de>"
 

--- a/build/package/docker/GoReleaser.Dockerfile
+++ b/build/package/docker/GoReleaser.Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=
 FROM        ${ARCH}debian:stretch-slim
 
-ENV         EXPORTER_VERSION=1.6
+ENV         EXPORTER_VERSION=1.6.1
 
 LABEL       MAINTAINER="Martin Helmich <m.helmich@mittwald.de>"
 


### PR DESCRIPTION
Super simple PR that bumps the varnish_exporter version and helps with part of #81

