### PR TITLE
*WIP* feat(health-check): health checks added for each container

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,6 +9,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "stable"
 
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,12 +152,20 @@ exporter:
     # runAsNonRoot: true
     # runAsUser: 1000
   resources: {}
-  livenessProbe: {}
-  # livenessProbe:
-  #   httpGet:
-  #    path: /
-  #    port: 6083
-  readinessProbe: {}
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 9131
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 3
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 9131
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
 
 service:
   type: ClusterIP
@@ -225,12 +233,18 @@ tolerations: []
 
 affinity: {}
 
-livenessProbe: {}
-# livenessProbe:
-#   httpGet:
-#    path: /
-#    port: 6083
-readinessProbe: {}
+livenessProbe:
+  tcpSocket:
+    port: 8090
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 3
+readinessProbe:
+  tcpSocket:
+    port: 8090
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 3
 
 vclTemplate: |
   vcl 4.0;


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
This PR adds liveness/readiness probes for each possible container in a pod. It will make us ensure that our deployments are healthy all the time. This issue also reopened as a new PR because PR #117 is staled.

**Which issue(s) this PR fixes:**
Fixes #57 

**Special notes for your reviewer:**
I had to add **tcpSocket** health probes for signaller port(8090) because application normally opens a single port, without varnish-exporter:
```shell
root@kube-httpcache-0:/# netstat -lntpu
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp6       0      0 :::8090                 :::*                    LISTEN      1/kube-httpcache
```

Also i have no idea how to publish new Helm chart https://helm.mittwald.de Helm repository. I could not examine deeply but i hope current Github actions handle that already.