### PR TITLE
Read secret file before each authentication attempt

### DIFF
--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -69,11 +69,6 @@ func NewVarnishController(
 		return nil, err
 	}
 
-	secret, err := ioutil.ReadFile(secretFile)
-	if err != nil {
-		return nil, err
-	}
-
 	return &VarnishController{
 		SecretFile:           secretFile,
 		Storage:              storage,
@@ -90,7 +85,6 @@ func NewVarnishController(
 		backendUpdates:       backendUpdates,
 		varnishSignaller:     varnishSignaller,
 		configFile:           "/tmp/vcl",
-		secret:               secret,
 	}, nil
 }
 

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -38,7 +38,6 @@ type VarnishController struct {
 	backend            *watcher.EndpointConfig
 	varnishSignaller   *signaller.Signaller
 	configFile         string
-	secret             []byte
 	localAdminAddr     string
 	currentVCLName     string
 }

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os/exec"
 	"text/template"
 
@@ -72,7 +73,12 @@ func (v *VarnishController) rebuildConfig(ctx context.Context, i int) error {
 		return err
 	}
 
-	err = client.Authenticate(ctx, v.secret)
+	secret, err := ioutil.ReadFile(v.SecretFile)
+	if err != nil {
+		return err
+	}
+
+	err = client.Authenticate(ctx, secret)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes the `secret` variable from the controller and instead reads the secret file before each authentication attempt.

Fixes #56 by ensuring that the correct password is used for all reloads.

Relevant varnish docs: https://github.com/varnishcache/varnish-cache/blob/606977bbfb624ead38e9c8648beac0b3906a4294/doc/sphinx/users-guide/run_security.rst#cli-interface-authentication, specifically: 

> You can change the contents of the secret file while varnishd runs, it is read every time a CLI connection is authenticated.