### PR TITLE
force recreating pods when configmap has been changed

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -19,10 +19,11 @@ spec:
       {{- include "kube-httpcache.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "kube-httpcache.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -20,10 +20,11 @@ spec:
       {{- include "kube-httpcache.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "kube-httpcache.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
Pods need to manually be recreated when configmap (configuration template) change.
Adding an annotation from configmap checksum to deployment files leads to recreating pods after any change in configurations.