### PR TITLE
add explicit appProtocol spec to http service

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -11,6 +11,7 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.target }}
       protocol: TCP
+      appProtocol: TCP
     - name: "signaller"
       port: 8090
       targetPort: 8090


### PR DESCRIPTION
I am currently patching manually the helm chart at each release to have the service to work with Istio so I propose this change

the app protocol should be explicit, to prevent issues with Istio automatic protocol selection
cf https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
with current naming Istio will infer http/1 or http2

this should not impact other usages, and explicit appProtocol specification is also a good practice

thanks for your feedback
