### PR TITLE
Upgrade to debian:bullseye-slim 

### DIFF
--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN         set -x \
                 "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
             > "/etc/apt/sources.list.d/varnishcache_varnish60lts.list" \
             && \
-            apt-get -qq update && apt-get -qq install varnish \
+            apt-get -qq update && apt-get -qq install varnish=6.0.11-1~bullseye \
             && \
             apt-get -qq purge curl gnupg && \
             apt-get -qq autoremove && apt-get -qq autoclean && \

--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN         CGO_ENABLED=0 GOOS=linux \
                 -a cmd/kube-httpcache/main.go
 
 
-FROM        debian:stretch-slim AS final
+FROM        debian:bullseye-slim AS final
 
 ENV         EXPORTER_VERSION=1.6.1
 
@@ -29,11 +29,11 @@ RUN         set -x \
                 gnupg \
                 apt-transport-https \
             && \
-            curl -Ss -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - \
+            curl -fsSL https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - \
             && \
             printf "%s\n%s" \
-                "deb https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" \
-                "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" \
+                "deb https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
+                "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
             > "/etc/apt/sources.list.d/varnishcache_varnish60lts.list" \
             && \
             apt-get -qq update && apt-get -qq install varnish \

--- a/build/package/docker/GoReleaser.Dockerfile
+++ b/build/package/docker/GoReleaser.Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM        ${ARCH}debian:stretch-slim
+FROM        ${ARCH}debian:bullseye-slim
 
 ENV         EXPORTER_VERSION=1.6.1
 
@@ -18,8 +18,8 @@ RUN         apt-get -qq update && apt-get -qq upgrade \
             curl -Ss -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - \
             && \
             printf "%s\n%s" \
-                "deb https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" \
-                "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" \
+                "deb https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
+                "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
             > "/etc/apt/sources.list.d/varnishcache_varnish60lts.list" \
             && \
             apt-get -qq update && apt-get -qq install varnish \

--- a/build/package/docker/GoReleaser.Dockerfile
+++ b/build/package/docker/GoReleaser.Dockerfile
@@ -22,7 +22,7 @@ RUN         apt-get -qq update && apt-get -qq upgrade \
                 "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ bullseye main" \
             > "/etc/apt/sources.list.d/varnishcache_varnish60lts.list" \
             && \
-            apt-get -qq update && apt-get -qq install varnish \
+            apt-get -qq update && apt-get -qq install varnish=6.0.11-1~bullseye \
             && \
             apt-get -qq purge curl gnupg apt-transport-https && \
             apt-get -qq autoremove && apt-get -qq autoclean && \


### PR DESCRIPTION
**PR related to #156** 

Due to the EOL of `debian:stretch` i made a switch to `debian:bullseye`.

This PR is **untested**. 
Docker-Build works without errors but **functionality of varnish etc. was not tested.**
(It's friday EOB, we'll check it next week)

**"Why do you create a untested PR?"**

I created this PR because we had issues with connection to the stretch package-repos.
Seems like they were removed after a grace period.

But even this untested PR might help someone with this issue.

Tests of voluntaries are appreciated.

**EDIT1**: It's BOB and first tests seem to be promising.
Added a change pinning varnish to 6.0.11 because 6.5.* would be used otherwise.

**EDIT2**: It's already deployed to our production environment and no issues occurred so far.
(It's a portal with many thousands of users a day)