### PR TITLE
Add configurable annotations to service

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "kube-httpcache.fullname" . }}
   labels:
     {{- include "kube-httpcache.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -187,6 +187,7 @@ service:
   type: ClusterIP
   port: 80
   target: 8080
+#  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This adds configurable annotations to the service. This is sometimes necessary in cloud environments such as google to configure a backendconfig for health checks and other load balancing features:
```
service:
  type: ClusterIP
  port: 80
  target: 80
  annotations:
    cloud.google.com/backend-config: '{"default": "some-backendconfig"}'
    cloud.google.com/neg: '{"ingress": true}'
```