### PR TITLE
set minReadySeconds on deployment/statefulset

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds}}
+{{- end }}
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ include "kube-httpcache.fullname" . }}
+{{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds}}
+{{- end }}
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# leave time to external load balancer to register target before terminating next Pod
+minReadySeconds: 0
+
 # Enable StatefulSet (Deployment is default)
 useStatefulset:
   enabled: true


### PR DESCRIPTION
Allow to set minReadySeconds to wait for an external load balancer to registre the new target before stopping the next pod during a rolling update (AWS ALB for example)