### PR TITLE
Allow starting without service endpoints

### DIFF
--- a/cmd/kube-httpcache/internal/flags.go
+++ b/cmd/kube-httpcache/internal/flags.go
@@ -55,6 +55,8 @@ type KubeHTTPProxyFlags struct {
 		VCLTemplate          string
 		VCLTemplatePoll      bool
 		WorkingDir           string
+		FrontendInitTimeout  time.Duration
+		BackendInitTimeout   time.Duration
 	}
 	Readiness struct {
 		Enable  bool
@@ -107,6 +109,10 @@ func (f *KubeHTTPProxyFlags) Parse() error {
 	flag.StringVar(&f.Varnish.AdditionalParameters, "varnish-additional-parameters", "", "Additional Varnish start parameters (-p, seperated by comma), like 'ban_dups=on,cli_timeout=30'")
 	flag.BoolVar(&f.Varnish.VCLTemplatePoll, "varnish-vcl-template-poll", false, "poll for file changes instead of using inotify (useful on some network filesystems)")
 	flag.StringVar(&f.Varnish.WorkingDir, "varnish-working-dir", "", "varnish working directory (-n)")
+	flag.DurationVar(&f.Varnish.FrontendInitTimeout, "varnish-frontend-init-timeout", time.Duration(0),
+		"timeout for initial frontend configuration to be discovered. The default 0s means wait indefinitely. When timeout is reached, the controller will continue with an empty list of front-ends")
+	flag.DurationVar(&f.Varnish.BackendInitTimeout, "varnish-backend-init-timeout", time.Duration(0),
+		"timeout for initial backend configuration to be discovered. The default 0s means wait indefinitely. When timeout is reached, the controller will continue with an empty list of back-ends")
 
 	// present for BC only; no effect until #36 [1] has resolved
 	//   [1]: https://github.com/mittwald/kube-httpcache/issues/36

--- a/cmd/kube-httpcache/main.go
+++ b/cmd/kube-httpcache/main.go
@@ -133,6 +133,8 @@ func main() {
 		templateUpdates,
 		varnishSignaller,
 		opts.Varnish.VCLTemplate,
+		opts.Varnish.FrontendInitTimeout,
+		opts.Varnish.BackendInitTimeout,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR helps with https://github.com/mittwald/kube-httpcache/issues/222

It allows the start of the first Varnish Pod in a StatefulSet/Deployment before any Varnish Pod IP appears on the service Endpoints list.

When you enable liveness/readiness probes, the first instance is waiting for itself. In this PR, new CLI flags are added to define a timeout for frontends/backends initialization. This allows the first Pod to start anyway.

In the VCL you must handle cases when there are no frontends/backends and the liveness/readiness probe should behave in a way that will eventually allow k8s to add this instance to the endpoint list in the service. After that, the controller renders a new VCL with a non-empty list of frontends/backends.