### PR TITLE
render template in topologySpreadConstraint

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -38,7 +38,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- if kindIs "slice" . }}
         {{- toYaml . | nindent 8 }}
+        {{- else }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.initContainers }}
       initContainers:

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -39,7 +39,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- if kindIs "slice" . }}
         {{- toYaml . | nindent 8 }}
+        {{- else }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.initContainers }}
       initContainers:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,19 +104,18 @@ lifecycle: {}
   #     - -c
   #     - touch /etc/varnish/fail_probes; sleep 25
 
-topologySpreadConstraints: {}
-  # - topologyKey: topology.kubernetes.io/zone
-  #   maxSkew: 1
-  #   whenUnsatisfiable: ScheduleAnyway
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/name: kube-httpcache
-  # - topologyKey: kubernetes.io/hostname
-  #   maxSkew: 1
-  #   whenUnsatisfiable: ScheduleAnyway
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/name: kube-httpcache
+# topologySpreadConstraints (this value is evaluated as a template)
+topologySpreadConstraints: |
+  - topologyKey: topology.kubernetes.io/zone
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      {{- include "kube-httpcache.selectorLabels" . | nindent 4 }}
+  - topologyKey: kubernetes.io/hostname
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      {{- include "kube-httpcache.selectorLabels" . | nindent 4 }}
 
 initContainers: {}
 # initContainers: |


### PR DESCRIPTION
This allow to reuse all labels from Pods

The `if kindIs "slice"` keeps compatiblity with previous topologySpreadConstraints